### PR TITLE
Clarify that the Play Store does not have the latest version

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,3 +3,5 @@
 Android releases for [Joplin](http://joplin.cozic.net)
 
 This repository only hosts the Joplin APK files. The source code is at https://github.com/laurent22/joplin and the Google Play page at https://play.google.com/store/apps/details?id=net.cozic.joplin
+
+Note that due to issues with the Play Store's requirements, only versions up to 2.8.x are available there. Newer versions can be downloaded from this repository (through [Releases/Tags](https://github.com/laurent22/joplin-android/tags)). See [The 2.9 release notes](https://discourse.joplinapp.org/t/whats-new-in-joplin-2-9/28661#about-the-android-version-9) for more information about this issue.


### PR DESCRIPTION
This helps people understand that they need to manually install the package if they want the latest version.

Related: I've noticed that all 2.9.x versions are marked as "pre-release" in this repo, so not displayed in the "Releases" box on the main page of the repository, and only shown under "Tags", not "Releases". Is this intentional? Are these versions considered pre-releases? The [release notes](https://discourse.joplinapp.org/t/whats-new-in-joplin-2-9/28661#about-the-android-version-9) say "For the record the current 2.9 app works perfectly fine.", suggesting it is just a normal stable release?